### PR TITLE
fix(config): add fallbacks for missing env variables

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -103,7 +103,7 @@ export const env: IEnv = {
   /**
    * Pagination maximum size limit.
    */
-  PAGE_MAX_LIMIT: parseInt(process.env['PAGE_MAX_LIMIT']),
+  PAGE_MAX_LIMIT: parseInt(process.env['PAGE_MAX_LIMIT']) || 500,
 
   /** SMTP */
   SMTP_HOST: process.env['SMTP_HOST'],

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      API_BASE: '',
+      API_BASE: 'http://localhost:3001',
       CHAIN_ID: moonbaseAlpha.id,
       CLAIM_START: 0,
       CLAIM_END: 0,


### PR DESCRIPTION
- Set default PAGE_MAX_LIMIT to 500 in backend config to prevent undefined values
- Provide default API_BASE in frontend config for local development convenience