### PR TITLE
fix(config): improve fallback handling for environment variables

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -65,7 +65,7 @@ export const env: IEnv = {
   /**
    * Application environment info.
    */
-  APP_ENV: process.env['APP_ENV'] || 'development',
+  APP_ENV: process.env['APP_ENV'] || 'production',
   APP_SECRET: process.env['APP_SECRET'] || 'notasecret',
   APP_URL: process.env['APP_URL'] || 'http://localhost:8000',
 
@@ -78,7 +78,7 @@ export const env: IEnv = {
    * HTTP server hostname and port.
    */
   API_HOST: process.env['API_HOST'] || '127.0.0.1',
-  API_PORT: parseInt(process.env['API_PORT']) || 3001,
+  API_PORT: process.env['API_PORT'] ? parseInt(process.env['API_PORT']) : 3001,
 
   /**
    * Admin
@@ -90,40 +90,55 @@ export const env: IEnv = {
    * Mysql URL.
    */
   MYSQL_HOST: process.env['MYSQL_HOST'],
-  MYSQL_PORT: parseInt(process.env['MYSQL_PORT']) || 3306,
+  MYSQL_PORT: process.env['MYSQL_PORT']
+    ? parseInt(process.env['MYSQL_PORT'])
+    : 3306,
   MYSQL_DATABASE: process.env['MYSQL_DATABASE'],
   MYSQL_USER: process.env['MYSQL_USER'],
   MYSQL_PASSWORD: process.env['MYSQL_PASSWORD'],
-  MYSQL_POOL: parseInt(process.env['MYSQL_POOL']),
+  MYSQL_POOL: process.env['MYSQL_POOL']
+    ? parseInt(process.env['MYSQL_POOL'])
+    : 1,
 
   /**
    * Pagination default size limit.
    */
-  PAGE_DEFAULT_LIMIT: parseInt(process.env['PAGE_DEFAULT_LIMIT']) || 100,
+  PAGE_DEFAULT_LIMIT: process.env['PAGE_DEFAULT_LIMIT']
+    ? parseInt(process.env['PAGE_DEFAULT_LIMIT'])
+    : 100,
 
   /**
    * Pagination maximum size limit.
    */
-  PAGE_MAX_LIMIT: parseInt(process.env['PAGE_MAX_LIMIT']) || 500,
+  PAGE_MAX_LIMIT: process.env['PAGE_MAX_LIMIT']
+    ? parseInt(process.env['PAGE_MAX_LIMIT'])
+    : 500,
 
   /** SMTP */
-  SMTP_HOST: process.env['SMTP_HOST'],
-  SMTP_PORT: parseInt(process.env['SMTP_PORT']),
-  SMTP_USERNAME: process.env['SMTP_USERNAME'],
-  SMTP_PASSWORD: process.env['SMTP_PASSWORD'],
-  SMTP_NAME_FROM: process.env['SMTP_NAME_FROM'],
-  SMTP_EMAIL_FROM: process.env['SMTP_EMAIL_FROM'],
-  SMTP_EMAIL_FROM_HELLO: process.env['SMTP_EMAIL_FROM_HELLO'],
+  SMTP_HOST: process.env['SMTP_HOST'] || 'localhost',
+  SMTP_PORT: process.env['SMTP_PORT']
+    ? parseInt(process.env['SMTP_PORT'])
+    : 587,
+  SMTP_USERNAME: process.env['SMTP_USERNAME'] || '',
+  SMTP_PASSWORD: process.env['SMTP_PASSWORD'] || '',
+  SMTP_NAME_FROM: process.env['SMTP_NAME_FROM'] || 'System',
+  SMTP_EMAIL_FROM: process.env['SMTP_EMAIL_FROM'] || 'noreply@localhost',
+  SMTP_EMAIL_FROM_HELLO:
+    process.env['SMTP_EMAIL_FROM_HELLO'] || 'noreply@localhost',
 
   /**
    * Mysql test URL.
    */
   MYSQL_HOST_TEST: process.env['MYSQL_HOST_TEST'],
-  MYSQL_PORT_TEST: parseInt(process.env['MYSQL_PORT_TEST']) || 3306,
+  MYSQL_PORT_TEST: process.env['MYSQL_PORT_TEST']
+    ? parseInt(process.env['MYSQL_PORT_TEST'])
+    : 3306,
   MYSQL_DATABASE_TEST: process.env['MYSQL_DATABASE_TEST'],
   MYSQL_USER_TEST: process.env['MYSQL_USER_TEST'],
   MYSQL_PASSWORD_TEST: process.env['MYSQL_PASSWORD_TEST'],
-  MYSQL_POOL_TEST: parseInt(process.env['MYSQL_POOL_TEST']),
+  MYSQL_POOL_TEST: process.env['MYSQL_POOL_TEST']
+    ? parseInt(process.env['MYSQL_POOL_TEST'])
+    : 1,
 
   /**
    * Apillon
@@ -132,11 +147,17 @@ export const env: IEnv = {
   APILLON_KEY: process.env['APILLON_KEY'],
   APILLON_SECRET: process.env['APILLON_SECRET'],
   COLLECTION_UUID: process.env['COLLECTION_UUID'],
-  MAX_SUPPLY: parseInt(process.env['MAX_SUPPLY']) || 0,
+  MAX_SUPPLY: process.env['MAX_SUPPLY']
+    ? parseInt(process.env['MAX_SUPPLY'])
+    : 0,
 
   CAPTCHA_SECRET: process.env['CAPTCHA_SECRET'],
-  CLAIM_EXPIRES_IN: parseInt(process.env['CLAIM_EXPIRES_IN']) || 72,
+  CLAIM_EXPIRES_IN: process.env['CLAIM_EXPIRES_IN']
+    ? parseInt(process.env['CLAIM_EXPIRES_IN'])
+    : 72,
 
-  CLAIM_START: parseInt(process.env['CLAIM_START']),
+  CLAIM_START: process.env['CLAIM_START']
+    ? parseInt(process.env['CLAIM_START'])
+    : undefined,
   CLAIM_TYPE: ClaimType.AIRDROP,
 };


### PR DESCRIPTION
- Set default APP_ENV to 'production' to ensure consistency in non-development environments
- Add robust fallback logic for numeric environment variables to prevent undefined values
- Provide defaults for SMTP configuration to ensure functionality in missing env scenarios