### PR TITLE
fix(publish): version docker image

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       interval: 2s
 
   nft_studio_app:
-    image: apillon/nft-studio:latest
+    image: apillonio/nft-studio:0.0.1
     container_name: nft_studio_app
     depends_on:
       nft_studio_db:

--- a/backend/publish.sh
+++ b/backend/publish.sh
@@ -1,4 +1,8 @@
+if [ -z "$1" ]; then
+    echo "Error: Version argument is required (e.g. 0.0.1)" >&2
+    exit 1
+fi
+
 ./build-image.sh
-# TODO: we should probably properly version docker images
-docker tag nft-studio:latest apillon/nft-studio:latest
-docker push apillon/nft-studio:latest
+docker tag nft-studio:latest apillonio/nft-studio:$1
+docker push apillonio/nft-studio:$1


### PR DESCRIPTION
- Add validation to ensure a version argument is provided before publishing
- Update Docker image tagging to use provided version instead of 'latest'
- Fix repository name from 'apillon' to 'apillonio'
- Use version docker image 0.0.1 inside docker-compose