### PR TITLE
fix(config): update default API_HOST fallback

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -82,7 +82,7 @@ export const env: IEnv = {
   /**
    * HTTP server hostname and port.
    */
-  API_HOST: process.env['API_HOST'] || '127.0.0.1',
+  API_HOST: process.env['API_HOST'] || '0.0.0.0',
   API_PORT: process.env['API_PORT']
     ? parseInt(`${process.env['API_PORT']}`)
     : 3001,


### PR DESCRIPTION
- Change default API_HOST from '127.0.0.1' to '0.0.0.0' to allow external access.